### PR TITLE
Fix typo in wardrobe editor button

### DIFF
--- a/src/pages/WardrobeEditorPage.jsx
+++ b/src/pages/WardrobeEditorPage.jsx
@@ -23,7 +23,7 @@ const TopNavBar = () => {
       </div>
       <div className={styles.navActions}>
         <button className={`${styles.navButton} ${styles.primaryButton}`}>
-          Start to Deisgn
+          Start to Design
         </button>
         <div>회원가입</div>
         <div>로그인</div>


### PR DESCRIPTION
## Summary
- fix 'Start to Deisgn' typo in WardrobeEditorPage button

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e473e8c8832ca79e612335a1bdc9